### PR TITLE
Prevent grandchildren tbody to be filtered

### DIFF
--- a/dynamitable.jquery.js
+++ b/dynamitable.jquery.js
@@ -31,7 +31,7 @@
              * return dom
              **********************************************/
             this.getBody = function() {
-                return $dynamitable.find('tbody');
+                return $dynamitable.children('tbody');
             };
             
             /**********************************************


### PR DESCRIPTION
If there are sub-tables (tables within the `js-dynamitable` cells) then the `tr`s of those tables are hidden when filtering, which should not be. So using `children` instead of `find` avoids that problem.